### PR TITLE
Unread status bar item

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://img.shields.io/travis/karigari/vscode-chat.svg)](https://travis-ci.org/karigari/vscode-chat)
+[![Build Status](https://travis-ci.org/karigari/vscode-chat.svg?branch=master)](https://travis-ci.org/karigari/vscode-chat)
 [![](https://vsmarketplacebadge.apphb.com/installs/karigari.chat.svg)](https://marketplace.visualstudio.com/items?itemName=karigari.chat)
 [![](https://img.shields.io/vscode-marketplace/r/karigari.chat.svg)](https://marketplace.visualstudio.com/items?itemName=karigari.chat)
 [![](https://img.shields.io/badge/join-slack-orange.svg)](https://join.slack.com/t/karigarihq/shared_invite/enQtMzM5NzQxNjQxNTA1LTM0ZDFhNWQ3YmEyYmExZTY1ODJmM2U3NzExM2E0YmQxODcxYTgwYzczOTVkOGY5ODk2MWE0MzE2ODliNGU1ZDc)

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,17 +1,17 @@
 import { WebClient, WebClientOptions } from "@slack/client";
 import * as HttpsProxyAgent from "https-proxy-agent";
 import ConfigHelper from "../configuration";
-import { SlackUsers, SlackChannel, SlackMessages } from "../interfaces";
+import { SlackUsers, SlackChannel, SlackChannelMessages } from "../interfaces";
 
 const HISTORY_LIMIT = 50;
 
-export const getMessage = (raw: any): SlackMessages => {
+export const getMessage = (raw: any): SlackChannelMessages => {
   const { file, ts, user, text, edited, bot_id, attachments } = raw;
   const fileAttachment = file
     ? { name: file.name, permalink: file.permalink }
     : null;
 
-  let parsed: SlackMessages = {};
+  let parsed: SlackChannelMessages = {};
   parsed[ts] = {
     userId: user ? user : bot_id,
     timestamp: ts,
@@ -47,7 +47,7 @@ export default class SlackAPIClient {
     this.client = new WebClient(token, options);
   }
 
-  getConversationHistory = (channel: string): Promise<SlackMessages> => {
+  getConversationHistory = (channel: string): Promise<SlackChannelMessages> => {
     return this.client
       .apiCall("conversations.history", { channel, limit: HISTORY_LIMIT })
       .then((response: any) => {

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -24,7 +24,7 @@ export const getCommand = (text: string): MessageCommand => {
 class ViewController {
   messenger: SlackMessenger | undefined;
   ui: WebviewContainer | undefined;
-  isUiReady: Boolean = false; // Vuejs loaded
+  isUIReady: Boolean = false; // Vuejs loaded
   pendingMessage: UiMessage = undefined;
 
   constructor(
@@ -36,6 +36,8 @@ class ViewController {
     this.messenger = messenger;
   }
 
+  isUILoaded = () => !!this.ui;
+
   loadUi = () => {
     if (this.ui) {
       this.ui.reveal();
@@ -45,7 +47,7 @@ class ViewController {
         extensionPath,
         () => {
           this.ui = undefined;
-          this.isUiReady = false;
+          this.isUIReady = false;
         },
         isVisible => (isVisible ? this.onUiVisible() : null)
       );
@@ -104,7 +106,7 @@ class ViewController {
 
   handleInternal = (text: string) => {
     if (text === "is_ready") {
-      this.isUiReady = true;
+      this.isUIReady = true;
       return this.pendingMessage ? this.sendToUi(this.pendingMessage) : null;
     }
   };
@@ -161,7 +163,7 @@ class ViewController {
   };
 
   sendToUi = (uiMessage: UiMessage) => {
-    if (!this.isUiReady) {
+    if (!this.isUIReady) {
       this.pendingMessage = uiMessage;
     } else {
       const { messages } = uiMessage;

--- a/src/controller/index.ts
+++ b/src/controller/index.ts
@@ -29,7 +29,8 @@ class ViewController {
 
   constructor(
     private context: ExtensionContext,
-    private onUiVisible: () => void
+    private onUIVisible: () => void,
+    private onUIFocus: () => void
   ) {}
 
   setMessenger(messenger: SlackMessenger) {
@@ -49,7 +50,7 @@ class ViewController {
           this.ui = undefined;
           this.isUIReady = false;
         },
-        isVisible => (isVisible ? this.onUiVisible() : null)
+        isVisible => (isVisible ? this.onUIVisible() : null)
       );
       this.ui.setMessageHandler(this.sendToExtension);
     }
@@ -107,7 +108,11 @@ class ViewController {
   handleInternal = (text: string) => {
     if (text === "is_ready") {
       this.isUIReady = true;
-      return this.pendingMessage ? this.sendToUi(this.pendingMessage) : null;
+      return this.pendingMessage ? this.sendToUI(this.pendingMessage) : null;
+    }
+
+    if (text === "is_focused") {
+      this.onUIFocus();
     }
   };
 
@@ -162,7 +167,7 @@ class ViewController {
     };
   };
 
-  sendToUi = (uiMessage: UiMessage) => {
+  sendToUI = (uiMessage: UiMessage) => {
     if (!this.isUIReady) {
       this.pendingMessage = uiMessage;
     } else {

--- a/src/controller/markdowner.ts
+++ b/src/controller/markdowner.ts
@@ -1,10 +1,12 @@
 import * as EmojiConvertor from "emoji-js";
-import { UiMessage, SlackMessages } from "../interfaces";
+import { UiMessage, SlackChannelMessages } from "../interfaces";
 import * as str from "../strings";
 const MarkdownIt = require("markdown-it");
 const markdownItSlack = require("markdown-it-slack");
 
-export const emojify = (messages: SlackMessages): SlackMessages => {
+export const emojify = (
+  messages: SlackChannelMessages
+): SlackChannelMessages => {
   // Even though we are using markdown-it-slack, it does not
   // support emoji skin tones. If that changes, we can remove this method
   const emoji = new EmojiConvertor();
@@ -24,7 +26,9 @@ export const emojify = (messages: SlackMessages): SlackMessages => {
   return emojifiedMessages;
 };
 
-export const parseLinks = (messages: SlackMessages): SlackMessages => {
+export const parseLinks = (
+  messages: SlackChannelMessages
+): SlackChannelMessages => {
   // Looks for <url|title> pattern, and replaces them with normal markdown
   // The |pattern can be optional
   let parsed = {};
@@ -63,7 +67,9 @@ export const parseLinks = (messages: SlackMessages): SlackMessages => {
   return parsed;
 };
 
-export const markdownify = (messages: SlackMessages): SlackMessages => {
+export const markdownify = (
+  messages: SlackChannelMessages
+): SlackChannelMessages => {
   let markdowned = {};
   const md = new MarkdownIt({ breaks: true }).use(markdownItSlack);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -103,7 +103,7 @@ export function activate(context: vscode.ExtensionContext) {
           : store.updateChannels();
       })
       .then(() => {
-        return store.lastChannel && store.lastChannel.id
+        return !!store.lastChannelId
           ? new Promise((resolve, _) => {
               resolve();
             })
@@ -143,6 +143,10 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
+  if (store) {
+    store.dispose();
+  }
+
   if (reporter) {
     // Return promise sync this operation is async
     return reporter.dispose();

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -106,6 +106,5 @@ export interface IStore {
 
 export interface IMessenger {
   start: () => Promise<SlackCurrentUser>;
-  updateCurrentChannel: () => void;
   sendMessage: (text: string) => Promise<any>;
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -45,8 +45,12 @@ interface SlackMessage {
   content: MessageContent;
 }
 
-export interface SlackMessages {
+export interface SlackChannelMessages {
   [timestamp: string]: SlackMessage;
+}
+
+export interface SlackMessages {
+  [channelId: string]: SlackChannelMessages;
 }
 
 enum ChannelType {
@@ -75,7 +79,7 @@ export interface ExtensionMessage {
 }
 
 export interface UiMessage {
-  messages: SlackMessages;
+  messages: SlackChannelMessages;
   users: SlackUsers;
   channelName: string;
   currentUser: SlackCurrentUser;
@@ -84,13 +88,16 @@ export interface UiMessage {
 
 export interface IStore {
   slackToken: string;
-  lastChannel: SlackChannel;
+  lastChannelId: string;
   channels: SlackChannel[];
   currentUserInfo: SlackCurrentUser;
   users: SlackUsers;
   messages: SlackMessages;
-  clearMessages: () => void;
-  updateMessages: (newMessages: SlackMessages) => void;
+  getChannel: (string) => SlackChannel | undefined;
+  updateMessages: (
+    channelId: string,
+    newMessages: SlackChannelMessages
+  ) => void;
   loadChannelHistory: () => Promise<void>;
   getLastTimestamp: () => string;
   hasOldReadMarker: () => Boolean;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -99,8 +99,6 @@ export interface IStore {
     newMessages: SlackChannelMessages
   ) => void;
   loadChannelHistory: () => Promise<void>;
-  getLastTimestamp: () => string;
-  hasOldReadMarker: () => Boolean;
   updateReadMarker: (string) => void;
 }
 

--- a/src/messenger/index.ts
+++ b/src/messenger/index.ts
@@ -110,22 +110,7 @@ class SlackMessenger implements IMessenger {
     // this.rtmClient.sendMessage(cleanText, id)
     const cleanText = this.stripLinkSymbols(text);
     const { slackToken, lastChannelId: channelId } = this.store;
-    const lastTimestamp = this.store.getLastTimestamp();
     const client = new SlackAPIClient(slackToken);
-
-    if (this.store.hasOldReadMarker()) {
-      // Mark previous messages as read
-      const channel = this.store.getChannel(channelId);
-
-      if (channel) {
-        client.markChannel({ channel, ts: lastTimestamp }).then(response => {
-          const { ok } = response;
-          if (ok) {
-            this.store.updateReadMarker(lastTimestamp);
-          }
-        });
-      }
-    }
 
     return client
       .sendMessage({ channel: channelId, text: cleanText })

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,0 +1,41 @@
+import * as vscode from "vscode";
+import { SelfCommands } from "./constants";
+
+const OCTICON = "$(comment-discussion)";
+
+export default class StatusItem {
+  item: vscode.StatusBarItem;
+  unreadCount: number = 0;
+  isVisible: Boolean = false;
+
+  constructor() {
+    this.item = vscode.window.createStatusBarItem(
+      vscode.StatusBarAlignment.Left
+    );
+    this.item.command = SelfCommands.OPEN;
+  }
+
+  updateCount(unreads: number) {
+    this.unreadCount = unreads;
+    this.item.text = `${OCTICON} ${unreads} new`;
+    return this.unreadCount > 0 ? this.show() : this.hide();
+  }
+
+  show() {
+    if (!this.isVisible) {
+      this.item.show();
+      this.isVisible = true;
+    }
+  }
+
+  hide() {
+    if (this.isVisible) {
+      this.item.hide();
+      this.isVisible = false;
+    }
+  }
+
+  dispose() {
+    this.item.dispose();
+  }
+}

--- a/src/status.ts
+++ b/src/status.ts
@@ -12,7 +12,7 @@ export default class StatusItem {
     this.item = vscode.window.createStatusBarItem(
       vscode.StatusBarAlignment.Left
     );
-    this.item.command = SelfCommands.OPEN;
+    this.item.command = SelfCommands.CHANGE;
   }
 
   updateCount(unreads: number) {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,15 +3,18 @@ import SlackAPIClient from "../client";
 import {
   SlackChannel,
   SlackCurrentUser,
+  SlackChannelMessages,
   SlackMessages,
   SlackUsers,
   IStore,
   UiMessage
 } from "../interfaces";
+import StatusItem from "../status";
 import ConfigHelper from "../configuration";
 
 const stateKeys = {
-  LAST_CHANNEL: "lastChannel",
+  LAST_CHANNEL: "lastChannel", // TODO: deprecate this
+  LAST_CHANNEL_ID: "lastChannelId",
   CHANNELS: "channels",
   USER_INFO: "userInfo",
   USERS: "users"
@@ -36,12 +39,14 @@ function difference(setA, setB) {
 
 export default class Store implements IStore {
   slackToken: string;
-  lastChannel: SlackChannel;
+  lastChannelId: string;
   channels: SlackChannel[];
   currentUserInfo: SlackCurrentUser;
   users: SlackUsers;
-  messages: SlackMessages = {}; // of current channel
+  messages: SlackMessages = {};
   uiCallback: (message: UiMessage) => void;
+
+  statusItem: StatusItem;
 
   constructor(private context: vscode.ExtensionContext) {
     // Load token first
@@ -49,35 +54,79 @@ export default class Store implements IStore {
 
     // Now load global state
     const { globalState } = context;
-    this.lastChannel = globalState.get(stateKeys.LAST_CHANNEL);
     this.channels = globalState.get(stateKeys.CHANNELS);
     this.currentUserInfo = globalState.get(stateKeys.USER_INFO);
     this.users = globalState.get(stateKeys.USERS);
+    this.lastChannelId = globalState.get(stateKeys.LAST_CHANNEL_ID);
+    const lastChannel: SlackChannel = globalState.get(stateKeys.LAST_CHANNEL);
+
+    if (lastChannel && !this.lastChannelId) {
+      // We have old state lying around, which we will clean up now
+      this.lastChannelId = !!lastChannel.id ? lastChannel.id : null;
+      globalState.update(stateKeys.LAST_CHANNEL, null);
+    }
 
     if (this.currentUserInfo && this.slackToken) {
       if (this.currentUserInfo.token !== this.slackToken) {
         // Token has changed, all state is suspicious now
-        this.lastChannel = null;
+        this.lastChannelId = null;
         this.channels = null;
         this.currentUserInfo = null;
         this.users = null;
       }
     }
+
+    // Status bar item
+    this.statusItem = new StatusItem();
+  }
+
+  dispose() {
+    this.statusItem.dispose();
   }
 
   setUiCallback(uiCallback) {
     this.uiCallback = uiCallback;
   }
 
+  getChannel(channelId: string): SlackChannel {
+    const filtered = this.channels.filter(channel => channel.id === channelId);
+
+    if (filtered) {
+      return filtered[0];
+    }
+  }
+
   updateUi() {
-    const { name } = this.lastChannel;
+    const channel = this.getChannel(this.lastChannelId);
+    let name = "";
+
+    if (channel) {
+      name = channel.name;
+    }
+
     this.uiCallback({
-      messages: this.messages,
+      messages: this.messages[this.lastChannelId],
       users: this.users,
       currentUser: this.currentUserInfo,
       channelName: name,
       statusText: ""
     });
+  }
+
+  updateUnreadCount() {
+    const unreads = this.channels.map(channel => {
+      const { id, readTimestamp } = channel;
+      return !!readTimestamp
+        ? Object.keys(this.messages[id]).filter(ts => {
+            const isSomeotherUser =
+              this.messages[id][ts].userId !== this.currentUserInfo.id;
+            const isNewTimestamp = +ts > +readTimestamp;
+            return isSomeotherUser && isNewTimestamp;
+          }).length
+        : 0;
+    });
+    const totalUnreads = unreads.reduce((a, b) => a + b, 0);
+    this.statusItem.updateCount(totalUnreads);
   }
 
   updateUsers = (): Promise<SlackUsers> => {
@@ -109,8 +158,11 @@ export default class Store implements IStore {
   };
 
   updateLastChannel = (channel: SlackChannel): Thenable<void> => {
-    this.lastChannel = channel;
-    return this.context.globalState.update(stateKeys.LAST_CHANNEL, channel);
+    this.lastChannelId = channel.id;
+    return this.context.globalState.update(
+      stateKeys.LAST_CHANNEL_ID,
+      channel.id
+    );
   };
 
   updateCurrentUser = (userInfo: SlackCurrentUser): Thenable<void> => {
@@ -118,27 +170,23 @@ export default class Store implements IStore {
     return this.context.globalState.update(stateKeys.USER_INFO, userInfo);
   };
 
-  clearMessages = () => {
-    this.messages = {};
-  };
-
-  updateMessages = (newMessages: SlackMessages) => {
-    this.messages = {
-      ...this.messages,
-      ...newMessages
-    };
+  updateMessages = (channelId: string, newMessages: SlackChannelMessages) => {
+    const channelMessages = { ...this.messages[channelId], ...newMessages };
+    this.messages[channelId] = channelMessages;
 
     // Remove undefined, after message deleted
-    Object.keys(this.messages).forEach(key => {
-      if (typeof this.messages[key] === "undefined") {
-        delete this.messages[key];
+    Object.keys(this.messages[channelId]).forEach(key => {
+      if (typeof this.messages[channelId][key] === "undefined") {
+        delete this.messages[channelId][key];
       }
     });
 
     // Check if we have all users. Since there is not bots.list API
     // method, it is possible that a bot user is not in our store
     const userIds = new Set(
-      (<any>Object).values(this.messages).map(message => message.userId)
+      (<any>Object)
+        .values(this.messages[channelId])
+        .map(message => message.userId)
     );
     const allIds = new Set(Object.keys(this.users));
     if (!isSuperset(allIds, userIds)) {
@@ -146,6 +194,7 @@ export default class Store implements IStore {
     }
 
     this.updateUi();
+    this.updateUnreadCount();
   };
 
   fillUpBots(missingIds: Set<any>): Promise<any> {
@@ -172,11 +221,10 @@ export default class Store implements IStore {
 
   loadChannelHistory(): Promise<void> {
     const client = new SlackAPIClient(this.slackToken);
-
     return client
-      .getConversationHistory(this.lastChannel.id)
+      .getConversationHistory(this.lastChannelId)
       .then(messages => {
-        this.updateMessages(messages);
+        this.updateMessages(this.lastChannelId, messages);
       })
       .catch(error => {
         console.error(error);
@@ -184,17 +232,34 @@ export default class Store implements IStore {
   }
 
   getLastTimestamp(): string {
-    const timestamps = Object.keys(this.messages)
-      .filter(tsKey => this.messages[tsKey].userId !== this.currentUserInfo.id)
+    const id = this.lastChannelId;
+    const timestamps = Object.keys(this.messages[id])
+      .filter(
+        tsKey => this.messages[id][tsKey].userId !== this.currentUserInfo.id
+      )
       .map(tsString => +tsString);
     return Math.max(...timestamps).toString();
   }
 
   hasOldReadMarker(): Boolean {
-    return this.getLastTimestamp() !== this.lastChannel.readTimestamp;
+    const channel = this.getChannel(this.lastChannelId);
+    if (channel) {
+      return this.getLastTimestamp() !== channel.readTimestamp;
+    }
   }
 
   updateReadMarker(ts: string): void {
-    this.lastChannel.readTimestamp = ts;
+    // TODO: this should save the state locally?
+    this.channels = this.channels.map(channel => {
+      const { id } = channel;
+      if (id === this.lastChannelId) {
+        return {
+          ...channel,
+          readTimestamp: ts
+        };
+      } else {
+        return channel;
+      }
+    });
   }
 }

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -1,4 +1,5 @@
 export const CHANGE_CHANNEL_TITLE = "Select a channel";
+export const RELOAD_CHANNELS = "Reload Channels";
 export const INVALID_CHANNEL = "Invalid channel selected";
 export const TOKEN_NOT_FOUND = "Slack token not found in settings.";
 export const INVALID_COMMAND = text => `${text} is not a recognised command.`;

--- a/src/ui/static.js
+++ b/src/ui/static.js
@@ -2,19 +2,16 @@ const vscode = acquireVsCodeApi();
 
 const SAME_GROUP_TIME = 5 * 60; // seconds
 
-function openLink(href) {
-  // Handler for <a> tags in this view
+function sendMessage(text, type) {
   vscode.postMessage({
-    type: "link",
-    text: href
+    type,
+    text
   });
 }
 
-function sendCommand(text) {
-  vscode.postMessage({
-    type: "command",
-    text
-  });
+function openLink(href) {
+  // Handler for <a> tags in this view
+  return sendMessage(href, "link");
 }
 
 function hashCode(str) {
@@ -264,6 +261,7 @@ Vue.component("form-section", {
           v-model="text"
           v-bind:placeholder="placeholder"
           v-on:keydown="onKeydown"
+          v-on:focus="onFocus"
           v-focus
           rows="1">
         </textarea>
@@ -275,15 +273,11 @@ Vue.component("form-section", {
   methods: {
     onSubmit: function(event) {
       type = this.text.startsWith("/") ? "command" : "text";
-      vscode.postMessage({
-        type,
-        text: this.text
-      });
+      sendMessage(this.text, type);
       this.text = "";
     },
-    focusInput: function() {
-      const { messageInput } = this.$refs;
-      return messageInput ? messageInput.focus() : null;
+    onFocus: function(event) {
+      return sendMessage("is_focused", "internal");
     },
     onKeydown: function(event) {
       // Usability fixes
@@ -308,10 +302,7 @@ Vue.component("form-section", {
     }
   },
   mounted() {
-    return vscode.postMessage({
-      type: "internal",
-      text: "is_ready"
-    });
+    return sendMessage("is_ready", "internal");
   }
 });
 


### PR DESCRIPTION
Part 1: update unread count for new messages received after activation

- [x] Status bar item showing unread count
- [x] Store changes to maintain unreads
- [x] Fix command that is triggered when status bar item is clicked
- [x] Show unread counts in change channel quick pick
- [x] Mark message as read without having to send a message

Part 2: unread count for messages received before activation
- [ ] Get unread count from the slack api. Also figure out the extension activation for this use-case.