### PR TITLE
Fix sending text at composition end enter key event

### DIFF
--- a/src/webview/static.js
+++ b/src/webview/static.js
@@ -279,7 +279,8 @@ Vue.component("form-section", {
   },
   data: function() {
     return {
-      text: ""
+      text: "",
+      inComposition: false
     };
   },
   template: /* html */ `
@@ -318,7 +319,7 @@ Vue.component("form-section", {
       // Usability fixes
       // 1. Multiline support: only when shift + enter are pressed
       // 2. Submit on enter (without shift)
-      if (event.code === "Enter" && !event.shiftKey) {
+      if (event.code === "Enter" && !event.shiftKey && !this.inComposition) {
         event.preventDefault();
 
         if (this.text) {
@@ -337,6 +338,14 @@ Vue.component("form-section", {
     }
   },
   mounted() {
+    this.$refs.messageInput.addEventListener("compositionstart",  event => {
+      this.inComposition = true;
+    })
+
+    this.$refs.messageInput.addEventListener("compositionend",  event => {
+      this.inComposition = false;
+    })
+
     return sendMessage("is_ready", "internal");
   }
 });


### PR DESCRIPTION
Hi @arjun27 , thanks for this awesome extension 💯 

This PR prevents sending text when IME is in composition mode.

### Before

![vscode-chat-composition-before](https://user-images.githubusercontent.com/4230968/44905170-d69fa180-ad43-11e8-9367-3fa44294b8fa.gif)

### After

![vscode-chat-composition-after](https://user-images.githubusercontent.com/4230968/44905195-e7e8ae00-ad43-11e8-9755-465f835d4ef4.gif)

