### PR TITLE
(slack) Remove deleted users from DM options

### DIFF
--- a/src/slack/client.ts
+++ b/src/slack/client.ts
@@ -114,7 +114,8 @@ export default class SlackAPIClient {
       let users: Users = {};
 
       if (ok) {
-        members.forEach(member => {
+        const activeMembers = members.filter(member => !member.deleted);
+        activeMembers.forEach(member => {
           const { id, profile, real_name, name } = member;
           const { display_name, image_72, image_24 } = profile;
           users[id] = {


### PR DESCRIPTION
Users that were previously deleted from a workspace were visible in the
DM section of the extension. After filtering, the member of the
workspace on whether or not they are deleted, issue #172 should be
fixed.

I got too excited to attempt a fix for this issue. Not able to test because I can't sign in on Linux for some reason. Worked on Mac earlier today.