### PR TITLE
multiple slack workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to the vscode-chat extension will be documented in this file. This follows the [Keep a Changelog](http://keepachangelog.com/) format.
 
+## [0.10.0] - 2019-01-21
+
+### Added
+
+- Added support for multiple workspaces in Slack. Run the `Sign in with Slack` command to add new workspaces; Use the tree view to change between Slack workspaces.
+
+### Fixed
+
+- Render attachments in Discord messages.
+- Usability improvements in selecting which Slack channels should be shown.
+
 ## [0.9.2] - 2019-01-04
 
 ### Fixed

--- a/oauth-service/utils.ts
+++ b/oauth-service/utils.ts
@@ -22,8 +22,8 @@ export const getIssueUrl = (errorMessage: string, serviceName: string) => {
   return `${baseUrl}?title=${encode(title)}&body=${encode(body)}`;
 };
 
-export const getRedirect = (token: string, serviceName: string) => {
-  return `vscode://karigari.chat/redirect?token=${token}&service=${serviceName}`;
+export const getRedirect = (token: string, service: string, team: string) => {
+  return `vscode://karigari.chat/redirect?token=${token}&service=${service}&team=${team}`;
 };
 
 export const getRedirectError = (errorMessage: string, serviceName: string) => {

--- a/package.json
+++ b/package.json
@@ -121,6 +121,11 @@
           "when": "chat:slack"
         },
         {
+          "id": "chat.treeView.unreads.slack",
+          "name": "Unreads",
+          "when": "chat:slack"
+        },
+        {
           "id": "chat.treeView.channels.slack",
           "name": "Channels",
           "when": "chat:slack"
@@ -145,6 +150,11 @@
         {
           "id": "chat.treeView.workspaces.discord",
           "name": "Workspaces",
+          "when": "chat:discord"
+        },
+        {
+          "id": "chat.treeView.unreads.discord",
+          "name": "Unreads",
           "when": "chat:discord"
         },
         {

--- a/package.json
+++ b/package.json
@@ -116,8 +116,8 @@
     "views": {
       "chatActivityViewSlack": [
         {
-          "id": "chat.treeView.unreads.slack",
-          "name": "Unreads",
+          "id": "chat.treeView.workspaces.slack",
+          "name": "Workspaces",
           "when": "chat:slack"
         },
         {
@@ -143,8 +143,8 @@
       ],
       "chatActivityViewDiscord": [
         {
-          "id": "chat.treeView.unreads.discord",
-          "name": "Unreads",
+          "id": "chat.treeView.workspaces.discord",
+          "name": "Workspaces",
           "when": "chat:discord"
         },
         {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
       },
       {
         "command": "extension.chat.changeWorkspace",
-        "title": "Chat: Change Discord Workspace"
+        "title": "Chat: Change Workspace"
       },
       {
         "command": "extension.chat.authenticate",

--- a/src/discord/index.ts
+++ b/src/discord/index.ts
@@ -43,6 +43,18 @@ const getMessageContent = (
 const getMessage = (raw: Discord.Message): Message => {
   const { author, createdTimestamp, content, reactions, editedTimestamp } = raw;
   const timestamp = (createdTimestamp / 1000).toString();
+  let attachment = undefined;
+  const attachments = raw.attachments.array();
+
+  if (attachments.length > 0) {
+    // This only shows the first attachment
+    const selected = attachments[0];
+    attachment = {
+      name: selected.filename,
+      permalink: selected.url
+    };
+  }
+
   return {
     timestamp,
     userId: author.id,
@@ -50,6 +62,7 @@ const getMessage = (raw: Discord.Message): Message => {
     isEdited: !!editedTimestamp,
     content: getMessageContent(raw),
     replies: {},
+    attachment,
     reactions: reactions.map(rxn => ({
       name: rxn.emoji.name,
       count: rxn.count,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -223,17 +223,13 @@ export function activate(context: vscode.ExtensionContext) {
     }
   };
 
-  const changeWorkspace = async () => {
-    // Discord only for now
-    if (manager.isProviderEnabled("discord")) {
-      const newTeam = await askForWorkspace("discord");
-
-      if (!!newTeam) {
-        manager.updateCurrentWorkspace("discord", newTeam);
-      }
-
-      await manager.clearOldWorkspace("discord");
-      await setup(false, { provider: "discord", teamId: undefined });
+  const changeWorkspace = async (providerAndTeam?: any) => {
+    // TODO: when arg is undefined, ask for workspace
+    if (!!providerAndTeam) {
+      const { provider, team } = providerAndTeam;
+      manager.updateCurrentWorkspace(provider, team);
+      await manager.clearOldWorkspace(provider);
+      await setup(false, { provider, teamId: team.id });
     }
   };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -87,7 +87,7 @@ export function activate(context: vscode.ExtensionContext) {
     await manager.initializeProviders();
 
     if (manager.isProviderEnabled("discord")) {
-      if (!manager.getCurrentTeamFor("discord")) {
+      if (!manager.getCurrentTeamIdFor("discord")) {
         await askForWorkspace("discord");
       }
     }
@@ -261,9 +261,13 @@ export function activate(context: vscode.ExtensionContext) {
     }
 
     if (provider && team) {
-      manager.updateCurrentWorkspace(provider, team);
-      await manager.clearOldWorkspace(provider);
-      await setup(false, { provider, teamId: team.id });
+      const isDifferentTeam = team.id !== manager.getCurrentTeamIdFor(provider);
+
+      if (isDifferentTeam) {
+        manager.updateCurrentWorkspace(provider, team);
+        await manager.clearOldWorkspace(provider);
+        await setup(false, { provider, teamId: team.id });
+      }
     }
   };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -94,9 +94,8 @@ export function activate(context: vscode.ExtensionContext) {
 
     // TODO: In discord, user preferences are available after channels are fetched
     manager.updateUserPrefsForAll(); // async update
-    await manager.initializeUsersStateForAll();
+    await manager.initializeStateForAll();
     manager.subscribePresenceForAll();
-    await manager.initializeChannelsStateForAll();
     return manager.initializeVslsContactProvider();
   };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import {
   TRAVIS_SCHEME
 } from "./constants";
 import travis from "./bots/travis";
-import { ExtensionUriHandler } from "./uri";
+import { ExtensionUriHandler } from "./uriHandler";
 import * as utils from "./utils";
 import { askForAuth } from "./onboarding";
 import { ConfigHelper } from "./config";
@@ -67,7 +67,7 @@ export function activate(context: vscode.ExtensionContext) {
 
   const setup = async (
     canPromptForAuth: boolean,
-    newProvider: string | undefined
+    newInitialState: InitialState | undefined
   ): Promise<any> => {
     await store.runStateMigrations();
 
@@ -75,9 +75,9 @@ export function activate(context: vscode.ExtensionContext) {
       setupFreshInstall();
     }
 
-    if (!manager.isTokenInitialized || !!newProvider) {
-      // We force initialization if we are provided a newProvider
-      await manager.initializeToken(newProvider);
+    if (!manager.isTokenInitialized || !!newInitialState) {
+      // We force initialization if we are provided a newInitialState
+      await manager.initializeToken(newInitialState);
 
       if (!manager.isTokenInitialized) {
         handleNoToken(canPromptForAuth);
@@ -234,7 +234,7 @@ export function activate(context: vscode.ExtensionContext) {
     if (manager.isProviderEnabled("discord")) {
       await askForWorkspace("discord");
       await manager.clearOldWorkspace("discord");
-      await setup(false, "discord");
+      await setup(false, { provider: "discord", teamId: undefined });
     }
   };
 
@@ -511,7 +511,7 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(SelfCommands.RESET_STORE, reset),
     vscode.commands.registerCommand(
       SelfCommands.SETUP_NEW_PROVIDER,
-      ({ newProvider }) => setup(false, newProvider)
+      ({ newInitialState }) => setup(false, newInitialState)
     ),
     vscode.commands.registerCommand(
       SelfCommands.CONFIGURE_TOKEN,

--- a/src/manager/chatManager.ts
+++ b/src/manager/chatManager.ts
@@ -9,7 +9,8 @@ export class ChatProviderManager {
 
   constructor(
     private store: IStore,
-    private providerName: string,
+    public providerName: string,
+    public teamId: string | undefined,
     private chatProvider: IChatProvider,
     private parentManager: IManager
   ) {}

--- a/src/manager/index.ts
+++ b/src/manager/index.ts
@@ -53,7 +53,7 @@ export default class Manager implements IManager, vscode.Disposable {
     return !!cp;
   }
 
-  getCurrentTeamFor(provider: string) {
+  getCurrentTeamIdFor(provider: string) {
     const currentUser = this.store.getCurrentUser(provider);
     return !!currentUser ? currentUser.currentTeamId : undefined;
   }

--- a/src/manager/index.ts
+++ b/src/manager/index.ts
@@ -80,13 +80,13 @@ export default class Manager implements IManager, vscode.Disposable {
     return !!cp ? cp.isAuthenticated() : false;
   }
 
-  initializeToken = async (newProvider?: string) => {
+  initializeToken = async (newInitialState?: InitialState) => {
     let enabledProviders = this.getEnabledProviders();
 
-    if (!!newProvider) {
+    if (!!newInitialState) {
       // In addition to the enabled providers, we will
       // add support for this newProvider
-      enabledProviders.push(newProvider);
+      enabledProviders.push(newInitialState.provider);
     }
 
     for (const provider of enabledProviders) {

--- a/src/manager/index.ts
+++ b/src/manager/index.ts
@@ -247,11 +247,11 @@ export default class Manager implements IManager, vscode.Disposable {
     this.isTokenInitialized = false;
   }
 
-  clearOldWorkspace(provider: string) {
+  async clearOldWorkspace(provider: string) {
     // Clears users and channels so that we are loading them again
-    this.store.updateUsers(provider, {});
-    this.store.updateChannels(provider, []);
-    this.store.updateLastChannelId(provider, undefined);
+    await this.store.updateUsers(provider, {});
+    await this.store.updateChannels(provider, []);
+    await this.store.updateLastChannelId(provider, undefined);
   }
 
   async updateWebviewForProvider(provider: string, channelId: string) {

--- a/src/manager/treeView.ts
+++ b/src/manager/treeView.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import {
   WorkspacesTreeProvider,
+  UnreadsTreeProvider,
   ChannelTreeProvider,
   GroupTreeProvider,
   IMsTreeProvider
@@ -8,12 +9,14 @@ import {
 
 export class TreeViewManager implements vscode.Disposable {
   workspacesTreeProvider: WorkspacesTreeProvider;
+  unreadsTreeProvider: UnreadsTreeProvider;
   channelsTreeProvider: ChannelTreeProvider;
   imsTreeProvider: IMsTreeProvider;
   groupsTreeProvider: GroupTreeProvider;
 
   constructor(public provider: string) {
     this.workspacesTreeProvider = new WorkspacesTreeProvider(provider);
+    this.unreadsTreeProvider = new UnreadsTreeProvider(provider);
     this.channelsTreeProvider = new ChannelTreeProvider(provider);
     this.groupsTreeProvider = new GroupTreeProvider(provider);
     this.imsTreeProvider = new IMsTreeProvider(provider);
@@ -21,7 +24,7 @@ export class TreeViewManager implements vscode.Disposable {
 
   updateData(currentUserInfo: CurrentUser, channelLabels: ChannelLabel[]) {
     this.workspacesTreeProvider.updateCurrentUser(currentUserInfo);
-    this.workspacesTreeProvider.updateChannels(channelLabels);
+    this.unreadsTreeProvider.updateChannels(channelLabels);
     this.channelsTreeProvider.updateChannels(channelLabels);
     this.groupsTreeProvider.updateChannels(channelLabels);
     this.imsTreeProvider.updateChannels(channelLabels);
@@ -29,6 +32,7 @@ export class TreeViewManager implements vscode.Disposable {
 
   dispose() {
     this.workspacesTreeProvider.dispose();
+    this.unreadsTreeProvider.dispose();
     this.channelsTreeProvider.dispose();
     this.groupsTreeProvider.dispose();
     this.imsTreeProvider.dispose();

--- a/src/manager/treeView.ts
+++ b/src/manager/treeView.ts
@@ -1,33 +1,34 @@
 import * as vscode from "vscode";
 import {
-  UnreadsTreeProvider,
+  WorkspacesTreeProvider,
   ChannelTreeProvider,
   GroupTreeProvider,
   IMsTreeProvider
 } from "../tree";
 
 export class TreeViewManager implements vscode.Disposable {
-  unreadsTreeProvider: UnreadsTreeProvider;
+  workspacesTreeProvider: WorkspacesTreeProvider;
   channelsTreeProvider: ChannelTreeProvider;
   imsTreeProvider: IMsTreeProvider;
   groupsTreeProvider: GroupTreeProvider;
 
   constructor(public provider: string) {
-    this.unreadsTreeProvider = new UnreadsTreeProvider(provider);
+    this.workspacesTreeProvider = new WorkspacesTreeProvider(provider);
     this.channelsTreeProvider = new ChannelTreeProvider(provider);
     this.groupsTreeProvider = new GroupTreeProvider(provider);
     this.imsTreeProvider = new IMsTreeProvider(provider);
   }
 
-  updateData(channelLabels: ChannelLabel[]) {
-    this.unreadsTreeProvider.update(channelLabels);
-    this.channelsTreeProvider.update(channelLabels);
-    this.groupsTreeProvider.update(channelLabels);
-    this.imsTreeProvider.update(channelLabels);
+  updateData(currentUserInfo: CurrentUser, channelLabels: ChannelLabel[]) {
+    this.workspacesTreeProvider.updateCurrentUser(currentUserInfo);
+    this.workspacesTreeProvider.updateChannels(channelLabels);
+    this.channelsTreeProvider.updateChannels(channelLabels);
+    this.groupsTreeProvider.updateChannels(channelLabels);
+    this.imsTreeProvider.updateChannels(channelLabels);
   }
 
   dispose() {
-    this.unreadsTreeProvider.dispose();
+    this.workspacesTreeProvider.dispose();
     this.channelsTreeProvider.dispose();
     this.groupsTreeProvider.dispose();
     this.imsTreeProvider.dispose();

--- a/src/manager/views.ts
+++ b/src/manager/views.ts
@@ -140,7 +140,11 @@ export class ViewsManager implements vscode.Disposable {
 
     if (!!treeViewForProvider && this.parentManager.isAuthenticated(provider)) {
       const channelLabels = this.parentManager.getChannelLabels(provider);
-      treeViewForProvider.updateData(channelLabels);
+      const currentUserInfo = this.parentManager.getCurrentUserFor(provider);
+
+      if (!!currentUserInfo) {
+        treeViewForProvider.updateData(currentUserInfo, channelLabels);
+      }
     }
 
     if (!!this.vslsSessionTreeProvider) {

--- a/src/slack/client.ts
+++ b/src/slack/client.ts
@@ -203,9 +203,9 @@ export default class SlackAPIClient {
     if (ok) {
       return channels
         .map((channel: any) => {
-          const { is_channel, is_mpim, is_im, is_group } = channel;
+          const { is_channel, is_mpim, is_im, is_group, is_member } = channel;
 
-          if (is_channel) {
+          if (is_channel && is_member) {
             // Public channels
             return {
               id: channel.id,

--- a/src/test/manager.test.ts
+++ b/src/test/manager.test.ts
@@ -13,12 +13,13 @@ let slackProvider = new SlackChatProvider("test-token", manager);
 let slackManager = new ChatProviderManager(
   store,
   "slack",
+  "test-team-id",
   slackProvider,
   manager
 );
-manager.chatProviders.set('slack' as Providers, slackManager)
+manager.chatProviders.set("slack" as Providers, slackManager);
 
-suite("Manager tests", function () {
+suite("Manager tests", function() {
   setup(() => {
     const currentUser = {
       id: "user-id",
@@ -32,19 +33,19 @@ suite("Manager tests", function () {
     manager.initializeToken();
   });
 
-  test("Get enabled providers works", function () {
-    const enabledProviders = manager.getEnabledProviders();
+  test("Get enabled providers works", function() {
+    const enabledProviders = manager.getEnabledProviders().map(e => e.provider);
     assert.equal(enabledProviders.indexOf("slack") >= 0, true);
   });
 
-  test("Clear all works", function () {
-    assert.notEqual(manager.chatProviders.get('slack' as Providers), undefined)
+  test("Clear all works", function() {
+    assert.notEqual(manager.chatProviders.get("slack" as Providers), undefined);
     manager.clearAll();
     verify(mockedStore.clearProviderState("slack")).once();
-    assert.equal(manager.chatProviders.get('slack' as Providers), undefined)
+    assert.equal(manager.chatProviders.get("slack" as Providers), undefined);
   });
 
-  test("Authentication check works", function () {
+  test("Authentication check works", function() {
     assert.equal(slackManager.isAuthenticated(), true);
     when(mockedStore.getCurrentUser("slack")).thenReturn(undefined);
     assert.equal(slackManager.isAuthenticated(), false);

--- a/src/tree/base.ts
+++ b/src/tree/base.ts
@@ -1,0 +1,163 @@
+import * as vscode from "vscode";
+import { ChannelTreeItem } from "./treeItem";
+import { equals, notUndefined } from "../utils";
+
+export interface ISortingFunction {
+  (a: ChannelLabel, b: ChannelLabel): number;
+}
+
+export interface IFilterFunction {
+  (a: ChannelLabel): boolean;
+}
+
+export class BaseChannelsListTreeProvider
+  implements vscode.TreeDataProvider<ChatTreeNode>, vscode.Disposable {
+  private _onDidChangeTreeData = new vscode.EventEmitter<ChatTreeNode>();
+  readonly onDidChangeTreeData? = this._onDidChangeTreeData.event;
+  protected _disposables: vscode.Disposable[] = [];
+
+  protected sortingFn: ISortingFunction = (a: ChannelLabel, b: ChannelLabel) =>
+    a.label.localeCompare(b.label);
+  protected filterFn: IFilterFunction = () => true;
+  protected channelLabels: ChannelLabel[] = [];
+
+  constructor(protected providerName: string, protected viewId: string) {
+    this._disposables.push(
+      vscode.window.registerTreeDataProvider(this.viewId, this)
+    );
+  }
+
+  dispose() {
+    this._disposables.forEach(dispose => dispose.dispose());
+  }
+
+  async refresh(treeItem?: ChatTreeNode) {
+    return treeItem
+      ? this._onDidChangeTreeData.fire(treeItem)
+      : this._onDidChangeTreeData.fire();
+  }
+
+  getLabelsObject(
+    channeLabels: ChannelLabel[]
+  ): { [channelId: string]: ChannelLabel } {
+    let result: { [channelId: string]: ChannelLabel } = {};
+    channeLabels.forEach(label => {
+      const { channel } = label;
+      result[channel.id] = label;
+    });
+    return result;
+  }
+
+  updateChannels(channelLabels: ChannelLabel[]) {
+    const filtered = channelLabels.filter(this.filterFn).sort(this.sortingFn);
+    const prevLabels = this.getLabelsObject(this.channelLabels);
+    const newLabels = this.getLabelsObject(filtered);
+    this.channelLabels = filtered;
+    const prevKeys = new Set(Object.keys(prevLabels));
+    const newKeys = new Set(Object.keys(newLabels));
+
+    if (!equals(prevKeys, newKeys)) {
+      // We have new channels, so we are replacing everything
+      // Can potentially optimize this
+      return this.refresh();
+    }
+
+    // Looking for changes in presence and unread
+    Object.keys(newLabels).forEach(channelId => {
+      const newLabel = newLabels[channelId];
+      const prevLabel = prevLabels[channelId];
+
+      if (prevLabel.unread !== newLabel.unread) {
+        // Can we send just this element?
+        this.refresh();
+      }
+
+      if (prevLabel.presence !== newLabel.presence) {
+        // Can we send just this element?
+        this.refresh();
+      }
+    });
+  }
+
+  getParent = (element: ChatTreeNode): vscode.ProviderResult<ChatTreeNode> => {
+    const { channel } = element;
+
+    if (!!channel && !!channel.categoryName) {
+      return Promise.resolve(this.getItemForCategory(channel.categoryName));
+    }
+  };
+
+  getChildren = (
+    element?: ChatTreeNode
+  ): vscode.ProviderResult<ChatTreeNode[]> => {
+    if (!element) {
+      return this.getRootChildren();
+    }
+
+    if (!!element && element.isCategory) {
+      return this.getChildrenForCategory(element);
+    }
+  };
+
+  getChildrenForCategory = (
+    element: ChatTreeNode
+  ): vscode.ProviderResult<ChatTreeNode[]> => {
+    const { label: category } = element;
+    const channels = this.channelLabels
+      .filter(channelLabel => {
+        const { channel } = channelLabel;
+        return channel.categoryName === category;
+      })
+      .map(this.getItemForChannel);
+    return Promise.resolve(channels);
+  };
+
+  getRootChildren = (): vscode.ProviderResult<ChatTreeNode[]> => {
+    const channelsWithoutCategories = this.channelLabels
+      .filter(channelLabel => !channelLabel.channel.categoryName)
+      .map(this.getItemForChannel);
+    const categories: string[] = this.channelLabels
+      .map(channelLabel => channelLabel.channel.categoryName)
+      .filter(notUndefined);
+    const uniqueCategories = categories
+      .filter((item, pos) => categories.indexOf(item) === pos)
+      .map(category => this.getItemForCategory(category));
+    return Promise.resolve([...channelsWithoutCategories, ...uniqueCategories]);
+  };
+
+  getItemForChannel = (channelLabel: ChannelLabel): ChatTreeNode => {
+    const { label, presence, channel } = channelLabel;
+    return {
+      label,
+      presence,
+      channel,
+      isCategory: false,
+      user: undefined,
+      providerName: this.providerName
+    };
+  };
+
+  getItemForCategory = (category: string): ChatTreeNode => {
+    return {
+      label: category,
+      presence: UserPresence.unknown,
+      isCategory: true,
+      channel: undefined,
+      user: undefined,
+      providerName: this.providerName
+    };
+  };
+
+  getTreeItem = (element: ChatTreeNode): vscode.TreeItem => {
+    const { label, presence, isCategory, channel, user } = element;
+    const treeItem = new ChannelTreeItem(
+      label,
+      presence,
+      isCategory,
+      this.providerName,
+      channel,
+      user
+    );
+    return treeItem;
+  };
+}

--- a/src/tree/base.ts
+++ b/src/tree/base.ts
@@ -133,6 +133,7 @@ export class BaseChannelsListTreeProvider
       channel,
       isCategory: false,
       user: undefined,
+      team: undefined,
       providerName: this.providerName
     };
   };
@@ -144,6 +145,7 @@ export class BaseChannelsListTreeProvider
       isCategory: true,
       channel: undefined,
       user: undefined,
+      team: undefined,
       providerName: this.providerName
     };
   };

--- a/src/tree/index.ts
+++ b/src/tree/index.ts
@@ -4,6 +4,7 @@ import {
   IFilterFunction,
   ISortingFunction
 } from "./base";
+import { WorkspaceTreeItem } from "./treeItem";
 import { equals, notUndefined } from "../utils";
 
 export class WorkspacesTreeProvider extends BaseChannelsListTreeProvider {
@@ -42,6 +43,7 @@ export class WorkspacesTreeProvider extends BaseChannelsListTreeProvider {
       }
     }
 
+    // TODO: add unreads down below
     // if (!!element && element.isCategory) {
     //   return this.getChildrenForCategory(element);
     // }
@@ -51,11 +53,18 @@ export class WorkspacesTreeProvider extends BaseChannelsListTreeProvider {
     return {
       label: team.name,
       presence: UserPresence.unknown,
-      channel: undefined,
       isCategory: false,
+      channel: undefined,
       user: undefined,
+      team: team,
       providerName: this.providerName
     };
+  };
+
+  getTreeItem = (element: ChatTreeNode): vscode.TreeItem => {
+    const { label, team, providerName } = element;
+    const treeItem = new WorkspaceTreeItem(label, providerName, team);
+    return treeItem;
   };
 }
 
@@ -127,6 +136,7 @@ export class OnlineUsersTreeProvider extends BaseChannelsListTreeProvider {
       isCategory: false,
       user,
       channel: this.imChannels[user.id],
+      team: undefined,
       providerName: this.providerName
     };
   }

--- a/src/tree/index.ts
+++ b/src/tree/index.ts
@@ -4,7 +4,7 @@ import {
   IFilterFunction,
   ISortingFunction
 } from "./base";
-import { WorkspaceTreeItem } from "./treeItem";
+import { WorkspaceTreeItem, ChannelTreeItem } from "./treeItem";
 import { equals, notUndefined } from "../utils";
 
 export class WorkspacesTreeProvider extends BaseChannelsListTreeProvider {
@@ -35,18 +35,11 @@ export class WorkspacesTreeProvider extends BaseChannelsListTreeProvider {
     element?: ChatTreeNode
   ): vscode.ProviderResult<ChatTreeNode[]> => {
     if (!element) {
-      // return this.getRootChildren();
-
       if (!!this.userInfo) {
         const { teams } = this.userInfo;
         return teams.map(this.getItemForTeam);
       }
     }
-
-    // TODO: add unreads down below
-    // if (!!element && element.isCategory) {
-    //   return this.getChildrenForCategory(element);
-    // }
   };
 
   getItemForTeam = (team: Team): ChatTreeNode => {
@@ -66,6 +59,15 @@ export class WorkspacesTreeProvider extends BaseChannelsListTreeProvider {
     const treeItem = new WorkspaceTreeItem(label, providerName, team);
     return treeItem;
   };
+}
+
+export class UnreadsTreeProvider extends BaseChannelsListTreeProvider {
+  protected filterFn: IFilterFunction = c => c.unread > 0;
+  protected sortingFn: ISortingFunction = (a, b) => b.unread - a.unread;
+
+  constructor(provider: string) {
+    super(provider, `chat.treeView.unreads.${provider}`);
+  }
 }
 
 export class ChannelTreeProvider extends BaseChannelsListTreeProvider {

--- a/src/tree/index.ts
+++ b/src/tree/index.ts
@@ -16,15 +16,15 @@ export class WorkspacesTreeProvider extends BaseChannelsListTreeProvider {
   }
 
   updateCurrentUser(userInfo: CurrentUser) {
-    this.userInfo = userInfo;
-
     if (!this.userInfo) {
+      this.userInfo = userInfo;
       this.refresh();
     } else {
       const existingTeamIds = this.userInfo.teams.map(team => team.id);
       const newTeamIds = userInfo.teams.map(team => team.id);
 
       if (!equals(new Set(existingTeamIds), new Set(newTeamIds))) {
+        this.userInfo = userInfo;
         this.refresh();
       }
     }

--- a/src/tree/index.ts
+++ b/src/tree/index.ts
@@ -4,7 +4,7 @@ import {
   IFilterFunction,
   ISortingFunction
 } from "./base";
-import { WorkspaceTreeItem, ChannelTreeItem } from "./treeItem";
+import { WorkspaceTreeItem } from "./treeItem";
 import { equals, notUndefined } from "../utils";
 
 export class WorkspacesTreeProvider extends BaseChannelsListTreeProvider {
@@ -23,8 +23,14 @@ export class WorkspacesTreeProvider extends BaseChannelsListTreeProvider {
     } else {
       const existingTeamIds = this.userInfo.teams.map(team => team.id);
       const newTeamIds = userInfo.teams.map(team => team.id);
+      const hasTeamsChanged = !equals(
+        new Set(existingTeamIds),
+        new Set(newTeamIds)
+      );
+      const hasCurrentChanged =
+        this.userInfo.currentTeamId !== userInfo.currentTeamId;
 
-      if (!equals(new Set(existingTeamIds), new Set(newTeamIds))) {
+      if (hasCurrentChanged || hasTeamsChanged) {
         this.userInfo = userInfo;
         this.refresh();
       }
@@ -43,8 +49,16 @@ export class WorkspacesTreeProvider extends BaseChannelsListTreeProvider {
   };
 
   getItemForTeam = (team: Team): ChatTreeNode => {
+    let label = team.name;
+
+    if (!!this.userInfo) {
+      if (this.userInfo.currentTeamId === team.id) {
+        label = `${label} (active)`;
+      }
+    }
+
     return {
-      label: team.name,
+      label,
       presence: UserPresence.unknown,
       isCategory: false,
       channel: undefined,

--- a/src/tree/treeItem.ts
+++ b/src/tree/treeItem.ts
@@ -1,0 +1,73 @@
+import * as vscode from "vscode";
+import * as path from "path";
+import { SelfCommands } from "../constants";
+
+const BASE_PATH = path.join(
+  __filename,
+  "..",
+  "..",
+  "..",
+  "public",
+  "icons",
+  "presence"
+);
+
+const PRESENCE_ICONS = {
+  green: path.join(BASE_PATH, "green.svg"),
+  red: path.join(BASE_PATH, "red.svg"),
+  yellow: path.join(BASE_PATH, "yellow.svg")
+};
+
+export class ChannelTreeItem extends vscode.TreeItem {
+  constructor(
+    label: string,
+    presence: UserPresence,
+    isCategory: boolean,
+    providerName: string,
+    channel?: Channel,
+    user?: User
+  ) {
+    super(label);
+
+    if (!!channel) {
+      // This is a channel item
+      this.contextValue = "channel";
+      const chatArgs: ChatArgs = {
+        channelId: channel ? channel.id : undefined,
+        user,
+        providerName,
+        source: EventSource.activity
+      };
+      this.command = {
+        command: SelfCommands.OPEN_WEBVIEW,
+        title: "",
+        arguments: [chatArgs]
+      };
+    }
+
+    switch (presence) {
+      case UserPresence.available:
+        this.iconPath = {
+          light: PRESENCE_ICONS.green,
+          dark: PRESENCE_ICONS.green
+        };
+        break;
+      case UserPresence.doNotDisturb:
+        this.iconPath = {
+          light: PRESENCE_ICONS.red,
+          dark: PRESENCE_ICONS.red
+        };
+        break;
+      case UserPresence.idle:
+        this.iconPath = {
+          light: PRESENCE_ICONS.yellow,
+          dark: PRESENCE_ICONS.yellow
+        };
+        break;
+    }
+
+    if (isCategory) {
+      this.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+    }
+  }
+}

--- a/src/tree/treeItem.ts
+++ b/src/tree/treeItem.ts
@@ -18,6 +18,20 @@ const PRESENCE_ICONS = {
   yellow: path.join(BASE_PATH, "yellow.svg")
 };
 
+export class WorkspaceTreeItem extends vscode.TreeItem {
+  constructor(label: string, provider: string, team: Team | undefined) {
+    super(label);
+
+    if (!!team) {
+      this.command = {
+        command: SelfCommands.CHANGE_WORKSPACE,
+        title: "",
+        arguments: [{ team, provider }]
+      };
+    }
+  }
+}
+
 export class ChannelTreeItem extends vscode.TreeItem {
   constructor(
     label: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -303,6 +303,7 @@ interface ChatTreeNode {
   label: string;
   channel: Channel | undefined;
   user: User | undefined;
+  team: Team | undefined;
   isCategory: boolean;
   presence: UserPresence;
   providerName: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -242,6 +242,7 @@ interface IManager {
   getIMChannel: (provider: string, user: User) => Channel | undefined;
   getChannelLabels: (provider: string) => any;
   getUnreadCount: (provider: string, channel: Channel) => number;
+  getCurrentUserFor: (provider: string) => CurrentUser | undefined;
   getUserPresence: (
     provider: string,
     userId: string
@@ -306,3 +307,8 @@ interface ChatTreeNode {
   presence: UserPresence;
   providerName: string;
 }
+
+type InitialState = {
+  provider: string;
+  teamId: string | undefined;
+};

--- a/src/uriHandler.ts
+++ b/src/uriHandler.ts
@@ -8,11 +8,11 @@ export class ExtensionUriHandler implements vscode.UriHandler {
     // vscode://karigari.chat/redirect?url=foobar
     const { path, query } = uri;
     const parsed = this.parseQuery(query);
-    const { token, msg, service } = parsed;
+    const { token, msg, service, team } = parsed;
 
     switch (path) {
       case "/redirect":
-        return ConfigHelper.setToken(token, service);
+        return ConfigHelper.setToken(token, service, team);
       case "/error":
         return this.showIssuePrompt(msg, service);
     }


### PR DESCRIPTION
closes #26 

todo:

- [x] on changing the workspace from tree view, users that have presence status get duplicated over to the other workspace
- [x] on adding a new workspace to slack (via configure token), the DMs and groups list is not updated
- [x] change workspace command is now broken
- [ ] workspace tree item should continue to show the unread count 
- [x] existing slack users will need to migrate keychain account name