### PR TITLE
Fix usages of 'setup'

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The [VS Live Share Extension Pack](https://marketplace.visualstudio.com/items?it
 
 ## with Slack and Discord
 
-Optionally, you can also setup your Slack or Discord account to continuing using the same chat provider during a Live Share session.
+Optionally, you can also set up your Slack or Discord account to continuing using the same chat provider during a Live Share session.
 
 With Slack/Discord, you can also start a new session with online team members easily. You can also use the slash commands `/live share` and `/live end` to start or end sessions in a chat window.
 

--- a/docs/DISCORD.md
+++ b/docs/DISCORD.md
@@ -1,8 +1,8 @@
-## Setup Discord
+## Discord Setup
 
 ### Obtain token
 
-To setup Discord inside VS Code, you need to have your **Discord token**. To obtain your token, follow the steps [given here](https://discordhelp.net/discord-token).
+To set up Discord inside VS Code, you need to have your **Discord token**. To obtain your token, follow the steps [given here](https://discordhelp.net/discord-token).
 
 This is an unofficial token setup, one that is used by other Discord clients ([Discline](https://github.com/MitchWeaver/Discline), [terminal-discord](https://github.com/xynxynxyn/terminal-discord)), and the recommended approach by a Discord team member, as [given here](https://github.com/discordapp/discord-api-docs/issues/69#issuecomment-223886862):
 

--- a/src/strings.ts
+++ b/src/strings.ts
@@ -8,9 +8,9 @@ export const RELOAD_CHANNELS = "Reload Channels...";
 
 export const TOKEN_NOT_FOUND = "Setup Team Chat to work for your account.";
 
-export const SETUP_SLACK = "Setup Slack";
+export const SETUP_SLACK = "Set up Slack";
 
-export const SETUP_DISCORD = "Setup Discord";
+export const SETUP_DISCORD = "Set up Discord";
 
 export const REPORT_ISSUE = "Report issue";
 


### PR DESCRIPTION
Closes #318 

This PR fixes all usages of "setup" I could find, as detailed in #318 (turns out there aren't actually that many). Some things I left alone:

* mentions in `CHANGELOG.md`
* variables like `SETUP_DISCORD`, since I guess that could be interpreted as "variable regarding setup: discord"

Let me know if there's any other changes you want me to make!